### PR TITLE
Mark external resource so Mix knows of dependency

### DIFF
--- a/lib/burnex.ex
+++ b/lib/burnex.ex
@@ -4,7 +4,9 @@ defmodule Burnex do
   List from https://github.com/wesbos/burner-email-providers/blob/master/emails.txt
   """
 
-  @providers File.read!("priv/burner-email-providers/emails.txt")
+  @external_resource "priv/burner-email-providers/emails.txt"
+
+  @providers File.read!(@external_resource)
     |> String.split("\n")
     |> Enum.filter(fn str -> str != "" end)
 


### PR DESCRIPTION
By using `@external_resource`, Mix will know that the module depends on an external file. Changes to the contents of that file should then trigger a recompilation of the module. See https://hexdocs.pm/elixir/Module.html#module-external_resource

This is just a random contribution because I happened to read the code after seeing a tweet, and I maintain a library that also reads in a file at compile time. :wave: