### PR TITLE
Automatically update emails list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Releases
+
+on:
+  workflow_dispatch:
+  #push:
+  #  tags:
+  #    - .*
+
+jobs:
+  release:
+    name: Release new version
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Wait for tests
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-tests
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: Run dialyzer
+          ref: ${{ github.ref }}
+          timeoutSeconds: 3600
+
+      - name: Set up Elixir
+        uses: erlef/setup-elixir@v1
+        with:
+          otp-version: "22.2"
+          elixir-version: "1.9.4"
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache deps
+        id: cache-deps
+        uses: actions/cache@v2
+        with:
+          path: |
+            deps
+            _build
+          key: deps-${{ runner.os }}-${{ hashFiles('**/mix.lock') }}-git-${{ github.sha }}
+          restore-keys: |
+            deps-${{ runner.os }}-${{ hashFiles('**/mix.lock') }}
+            deps-${{ runner.os }}-$
+
+      - name: Install package dependencies
+        run: mix deps.get
+
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Publish hex package
+        run: mix hex.publish --yes
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,44 @@
+name: Daily list sync
+
+on:
+  schedule:
+    - cron: "30 15 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Download new list
+        run: ./update_providers.sh
+
+      - name: Check for list changes
+        continue-on-error: true
+        id: changes
+        run: git update-index --refresh && git diff-index HEAD
+
+      - name: Commit changes
+        if: steps.changes.outcome != 'success'
+        run: |
+          git checkout main --
+          git config user.email "benjamin@opencollective.com"
+          git config user.name "Burnex Bot"
+          git add priv/burner-email-providers/emails.txt
+
+      - name: Bump version
+        if: steps.changes.outcome != 'success'
+        run: |
+          CURRENT_VERSION=`cat VERSION`
+          NEW_PATCH=`echo $CURRENT_TAG | sed -E 's/v[0-9]+\.[0-9]+\.([0-9]+)/\1+1/' | bc`
+          NEW_TAG=`echo $CURRENT_TAG | sed -E "s/(v[0-9]+\.[0-9]+\.)[0-9]+/\1$NEW_PATCH/"`
+          echo $NEW_TAG > VERSION
+          git commit -m "chore: updated domain list"
+          git tag -a $NEW_TAG -m $NEW_TAG
+
+      - name: Push changes
+        if: steps.changes.outcome != 'success'
+        run: |
+          git push --follow-tags


### PR DESCRIPTION
Hello.

I found a beautiful solution of automatic updates of emails.txt file using Github Actions.
Here is the source: https://github.com/lindell/go-burner-email-providers/blob/main/.github/workflows/build.yaml

How it works:
1. Github Actions is starting every day
2. Emails.txt file is being downloaded from the source repo
3. If nothing has been changed, the workflow is finished
4. Otherwise the latest tag is being fetched, e.g. 3.1.0
5. Patch part of the version number will be increased, e.g. 3.1.1
6. Updated file will be commited to the master branch with a new tag
7. New Github release will be created for this tag
7. New version will then be uploaded into hex.pm

The only thing that should be done is adding up new secret HEX_API_KEY. Here should be stored the result of call `mix hex.user key generate --permission api:write`.