### PR TITLE
Suggest latest version of burnex for Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add `:burnex` to your list of dependencies in `mix.exs`.
 ```elixir
 def deps do
   [
-    {:burnex, "~> 1.0"}
+    {:burnex, "~> 3.1.0"}
   ]
 end
 ```


### PR DESCRIPTION
I don't know the reason of keeping the old version in Readme, but I think It's better to show the latest version in Readme to avoid any confusion.